### PR TITLE
Add tRPC-SvelteKit

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -856,3 +856,12 @@
   tags: [neovim, dotfiles, community]
   date_created: 2023-03-11
   date_added: 2023-08-01
+
+- title: tRPC-SvelteKit
+  url: https://icflorescu.github.io/trpc-sveltekit
+  repo: https://github.com/icflorescu/trpc-sveltekit
+  description: End-to-end typesafe APIs for your SvelteKit applications.
+  uses: [TypeScript, tRPC]
+  tags: [community, open source, NPM package, docs, dev tools]
+  date_created: 2022-02-10
+  date_added: 2023-08-03


### PR DESCRIPTION
Hey, I'm @icflorescu, the author of [tRPC-SvelteKit](https://icflorescu.github.io/trpc-sveltekit/):

[![tRPC-SvelteKit](https://user-images.githubusercontent.com/581999/204399415-18fddfb9-acdf-4e15-a945-a27f816e354e.png)](https://icflorescu.github.io/trpc-sveltekit/)

I've noticed that tRPC-SvelteKit was mentioned as being used by another listing item, but it wasn't in the list per se.

Thanks a lot for maintaining this list and thanks in advance for accepting my PR!